### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
 
     - run: pip install build
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import sys
 
 if sys.version_info < (3, 7):
-    sys.stderr.write("ERROR: RobotPy requires Python 3.6+\n")
+    sys.stderr.write("ERROR: RobotPy requires Python 3.7+\n")
     exit(1)
 
 import subprocess

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import sys
 
-if sys.version_info < (3, 6):
+if sys.version_info < (3, 7):
     sys.stderr.write("ERROR: RobotPy requires Python 3.6+\n")
     exit(1)
 
@@ -82,14 +82,13 @@ setup(
     packages=find_packages(),
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Python 3.6 will be EOL by EOY, per [PEP 494](https://www.python.org/dev/peps/pep-0494).

See-also: https://devguide.python.org/#status-of-python-branches