### PR TITLE
Fix bump workflow

### DIFF
--- a/.github/chainguard/bump-package.sts.yaml
+++ b/.github/chainguard/bump-package.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: 'repo:robotpy/mostrobotpy:ref:refs/tags/[1-9]+.*'
+claim_pattern:
+  workflow_ref: 'robotpy/mostrobotpy/\.github/workflows/dist.yml@.*'
+
+permissions:
+  workflows: write

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,15 +1,22 @@
 ---
 name: bump
 
-on: [repository_dispatch]
+on:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Package to bump'
+        required: true
+      package_version:
+        description: 'Package version'
+        required: true
 
 jobs:
   bump:
-    if: github.event_name == 'repository_dispatch' && github.event.action == 'tag'
     runs-on: ubuntu-latest
     env:
-      PACKAGE_NAME: ${{ github.event.client_payload.package_name }}
-      PACKAGE_VERSION: ${{ github.event.client_payload.package_version }}
+      PACKAGE_NAME: ${{ github.event.inputs.package_name }}
+      PACKAGE_VERSION: ${{ github.event.inputs.package_version }}
 
     steps:
     - name: Information

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -7,10 +7,14 @@ jobs:
   bump:
     if: github.event_name == 'repository_dispatch' && github.event.action == 'tag'
     runs-on: ubuntu-latest
+    env:
+      PACKAGE_NAME: ${{ github.event.client_payload.package_name }}
+      PACKAGE_VERSION: ${{ github.event.client_payload.package_version }}
+
     steps:
     - name: Information
       run: |
-        echo "Version update for ${{ github.event.client_payload.package_name }} -> ${{ github.event.client_payload.package_version }} requested"
+        echo "Version update for $PACKAGE_NAME -> $PACKAGE_VERSION requested"
     - uses: actions/checkout@v4
       with:
         token: ${{ secrets.REPO_ACCESS_TOKEN }}
@@ -27,7 +31,7 @@ jobs:
     - name: Bump requirements
       shell: bash
       run: |
-        python .github/workflows/bump.py ${{ github.event.client_payload.package_name }} ${{ github.event.client_payload.package_version }} "$(git describe --tags)"
+        python .github/workflows/bump.py "$PACKAGE_NAME" "$PACKAGE_VERSION" "$(git describe --tags)"
 
     - name: Commit and push
       shell: bash
@@ -35,12 +39,12 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "Github Action"
         git add pyproject.toml
-        git commit -m "Bump '${{ github.event.client_payload.package_name }}' dependency to '${{ github.event.client_payload.package_version }}'"
+        git commit -m "Bump '$PACKAGE_NAME' dependency to '$PACKAGE_VERSION'"
         git push
 
     - name: Tag and push
       shell: bash
       run: |
-        TAG=$(python .github/workflows/tag.py ${{ github.event.client_payload.package_name }} ${{ github.event.client_payload.package_version }} "$(git describe --tags --no-abbrev)")
-        git tag ${TAG}
-        git push origin ${TAG}
+        TAG=$(python .github/workflows/tag.py "$PACKAGE_NAME" "$PACKAGE_VERSION" "$(git describe --tags --no-abbrev)")
+        git tag "${TAG}"
+        git push origin "${TAG}"


### PR DESCRIPTION
The `ping-meta` job in `mostrobotpy` has failed this entire year. Example job: https://github.com/robotpy/mostrobotpy/actions/runs/13933788020/job/39002148579

Since it's broken anyway, let's take this opportunity to modernise this workflow using `workflow_dispatch` instead.